### PR TITLE
Improve error message when param doesn't exist

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ahaines/envy-build:1 as build
+FROM ahaines/envy-build:2 as build
 
 WORKDIR /go/src/github.com/haines/envy
 COPY . .

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,7 +1,7 @@
-FROM golang:1.10
+FROM golang:1.11
 
-ENV DEP_VERSION=0.4.1 \
-    DEP_SHA256SUM=31144e465e52ffbc0035248a10ddea61a09bf28b00784fd3fdd9882c8cbb2315
+ENV DEP_VERSION=0.5.0 \
+    DEP_SHA256SUM=287b08291e14f1fae8ba44374b26a2b12eb941af3497ed0ca649253e21ba2f83
 
 RUN set -x \
  && dep_binary=/usr/local/bin/dep \

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,7 @@
 
 
 [[projects]]
+  digest = "1:2a5c2786e981f2fcf76ad4cf30e77f5ba7338b3057ac7f49e569b250c3b117e2"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -14,6 +15,7 @@
     "aws/credentials/ec2rolecreds",
     "aws/credentials/endpointcreds",
     "aws/credentials/stscreds",
+    "aws/csm",
     "aws/defaults",
     "aws/ec2metadata",
     "aws/endpoints",
@@ -22,6 +24,7 @@
     "aws/signer/v4",
     "internal/sdkio",
     "internal/sdkrand",
+    "internal/sdkuri",
     "internal/shareddefaults",
     "private/protocol",
     "private/protocol/json/jsonutil",
@@ -31,70 +34,97 @@
     "private/protocol/rest",
     "private/protocol/xml/xmlutil",
     "service/ssm",
-    "service/sts"
+    "service/sts",
   ]
-  revision = "f6efafab9ddced9880456bc53096fa79f4596f5e"
-  version = "v1.13.27"
+  pruneopts = "UT"
+  revision = "c35fe9d06b9f0cefe538ecdb7501c84603119dfb"
+  version = "v1.15.56"
 
 [[projects]]
+  digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
-  revision = "346938d642f2ec3594ed81d874461961cd0faa76"
-  version = "v1.1.0"
+  pruneopts = "UT"
+  revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
+  version = "v1.1.1"
 
 [[projects]]
+  digest = "1:15e27372d379b45b18ac917b9dafc45c45485239490ece18cca97a12f9591146"
   name = "github.com/go-ini/ini"
   packages = ["."]
-  revision = "5e9692864e22d02ac79e2fa499cffb00520b4fea"
-  version = "v1.34.0"
+  pruneopts = "UT"
+  revision = "9c8236e659b76e87bf02044d06fde8683008ff3e"
+  version = "v1.39.0"
 
 [[projects]]
+  digest = "1:3a26588bc48b96825977c1b3df964f8fd842cd6860cc26370588d3563433cf11"
   name = "github.com/google/uuid"
   packages = ["."]
-  revision = "064e2069ce9c359c118179501254f67d7d37ba24"
-  version = "0.2"
+  pruneopts = "UT"
+  revision = "d460ce9f8df2e77fb1ba55ca87fafed96c607494"
+  version = "v1.0.0"
 
 [[projects]]
+  digest = "1:870d441fe217b8e689d7949fef6e43efbc787e50f200cb1e70dbca9204a1d6be"
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
+  pruneopts = "UT"
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
   version = "v1.0"
 
 [[projects]]
+  digest = "1:e22af8c7518e1eab6f2eab2b7d7558927f816262586cd6ed9f349c97a6c285c4"
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
+  pruneopts = "UT"
   revision = "0b12d6b5"
 
 [[projects]]
+  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = "UT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
-  branch = "master"
+  digest = "1:645cabccbb4fa8aab25a956cbcbdf6a6845ca736b2c64e197ca7cbb9d210b939"
   name = "github.com/spf13/cobra"
   packages = ["."]
-  revision = "a1f051bc3eba734da4772d60e2d677f47cf93ef4"
+  pruneopts = "UT"
+  revision = "ef82de70bb3f60c65fb8eebacbb2d122ef517385"
+  version = "v0.0.3"
 
 [[projects]]
+  digest = "1:c1b1102241e7f645bc8e0c22ae352e8f0dc6484b6cb4d132fa9f24174e0119e2"
   name = "github.com/spf13/pflag"
   packages = ["."]
-  revision = "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
-  version = "v1.0.0"
+  pruneopts = "UT"
+  revision = "298182f68c66c05229eb03ac171abe6e309ee79a"
+  version = "v1.0.3"
 
 [[projects]]
+  digest = "1:c40d65817cdd41fac9aa7af8bed56927bb2d6d47e4fea566a74880f5c2b1c41e"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
-    "require"
+    "require",
   ]
-  revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
-  version = "v1.2.1"
+  pruneopts = "UT"
+  revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
+  version = "v1.2.2"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "3b1e51cd5d6db43cfab350c5b87a60aca4b53d85c478d2d0cce4c1ff927c485b"
+  input-imports = [
+    "github.com/aws/aws-sdk-go/aws",
+    "github.com/aws/aws-sdk-go/aws/session",
+    "github.com/aws/aws-sdk-go/service/ssm",
+    "github.com/google/uuid",
+    "github.com/spf13/cobra",
+    "github.com/stretchr/testify/assert",
+    "github.com/stretchr/testify/require",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,18 +1,18 @@
 [[constraint]]
   name = "github.com/aws/aws-sdk-go"
-  version = "1.13.27"
+  version = "1.15.56"
 
 [[constraint]]
   name = "github.com/google/uuid"
-  version = "0.2"
+  version = "1.0.0"
 
 [[constraint]]
   name = "github.com/spf13/cobra"
-  branch = "master"
+  version = "0.0.3"
 
 [[constraint]]
   name = "github.com/stretchr/testify"
-  version = "1.2.1"
+  version = "1.2.2"
 
 [prune]
   go-tests = true

--- a/funcs.go
+++ b/funcs.go
@@ -40,7 +40,7 @@ func paramFunc(config *Config) (func(...string) (string, error), error) {
 			WithDecryption: aws.Bool(true),
 		})
 		if err != nil {
-			return "", err
+			return "", fmt.Errorf("failed to read %q from Parameter Store:\n%v", name, err)
 		}
 
 		return *result.Parameter.Value, nil

--- a/test/param_test.go
+++ b/test/param_test.go
@@ -115,3 +115,17 @@ func TestWithFullPathsToParameters(t *testing.T) {
 	assert.Equal(t, output, result.Stdout)
 	assert.Empty(t, result.Stderr)
 }
+
+func TestWithMissingParameter(t *testing.T) {
+	SkipInShortMode(t)
+
+	result := Envy().Env(Vars{
+		"AWS_ACCESS_KEY_ID":     TestAwsConfig.AccessKeyID,
+		"AWS_SECRET_ACCESS_KEY": TestAwsConfig.SecretAccessKey,
+		"AWS_REGION":            TestAwsConfig.Region,
+	}).Stdin(`{{ param "this" "does" "not" "exist" }}`).Run()
+
+	assert.Equal(t, 1, result.ExitStatus)
+	assert.Empty(t, result.Stdout)
+	assert.Contains(t, result.Stderr, `"/this/does/not/exist"`)
+}


### PR DESCRIPTION
Include the full path of the param in the error message to make debugging easier.